### PR TITLE
Gracefully handle SETUP packets whose wLength > 255.

### DIFF
--- a/valentyusb/usbcore/cpu/cdc_eptri.py
+++ b/valentyusb/usbcore/cpu/cdc_eptri.py
@@ -552,6 +552,11 @@ class CDCUsbPHY(Module, AutoDoc):
                     # 4: wIndex.eq(data_recv_payload_delayed),
                     # 5: wIndex.eq(Cat(wIndex[0:8], data_recv_payload_delayed)),
                     6: NextValue(wLength,usb.setup_data.fields.data),
+                    # Windows can and will send SETUP packets to this device with
+                    # wLength > 255. Pretend the request length is 255 in this case
+                    # since we don't ever send packets > 255 back. This avoids
+                    # interpreting wLength as modulo 256.
+                    7: If(usb.setup_data.fields.data > 0, NextValue(wLength, 255))
                     # 7: wLength.eq(Cat(wLength[0:8], data_recv_payload_delayed)),
                 }),
                 usb.setup_data.we.eq(1)


### PR DESCRIPTION
This isn't an exactly elegant solution, but since this device isn't responding to SETUP xfers with > 255 bytes anyway, I think saturating `wLength` to 255 is a reasonable solution.

The old behavior was to send back `wLength % 256` bytes. At least for this device, Windows will deliberately send a SETUP packet w/ length > 255- 265 in my case. The device responds with 9 bytes only, which is `265 % 256`. This is legal per USB, but the Windows driver interprets this as a malfunctioning device.

By forcing `wLength` to 255, we still don't send 255 bytes back, but we at least send all the data back we mean to send.